### PR TITLE
Check key "document" exists before parsing

### DIFF
--- a/downloader.py
+++ b/downloader.py
@@ -35,7 +35,7 @@ search = search.split(',')
 for message in data['messages']:
     if 'media' in message:
         for term in search:
-            if re.search(term, message['media']['document']['attributes'][0]['file_name'], re.IGNORECASE):
+            if 'document' in message['media'] and re.search(term, message['media']['document']['attributes'][0]['file_name'], re.IGNORECASE):
                 print(' Download ' + message['media']['document']['attributes'][0]['file_name'])
                 response = urlopen('https://tg.i-c-a.su/media/' + config.get('channel', 'name') + '/' + str(message['id']))
                 file = open(config.get('channel', 'download') + message['media']['document']['attributes'][0]['file_name'], 'wb')


### PR DESCRIPTION
Check if the key "document" key exists on message['media'] before parsing, otherwise script fails

To reproduce configure CERT-PA channel @certpaitalia; they usually don't attach files to the news. Launch the script and you see following error

```
gmellini@19-04:~/Scrivania/OpenSource/DL-Telegram-by-file-attachment$ ./downloader.py 
DL-Telegram-by-file-attachment started...
  Config loaded!
Traceback (most recent call last):
  File "./downloader.py", line 40, in <module>
    if 'webpage' in message['media'] and re.search(term, message['media']['document']['attributes'][0]['file_name'], re.IGNORECASE):
KeyError: 'document'
gmellini@19-04:~/Scrivania/OpenSource/DL-Telegram-by-file-attachment$

```
With the fix is ok